### PR TITLE
Add underscore dependency to package.json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "less-middleware": "*",
     "twitter-bootstrap": "~2.1.1",
     "request": "~2.16.6",
+    "underscore": "~1.5.1",
     "timezone": "0.0.19"
   }
 }


### PR DESCRIPTION
Fixes the issue where underscore can't be found in app/routes/index.js on deploy.
