### PR TITLE
Add instruction for requesting talks via GH issues

### DIFF
--- a/request-for-talk.md
+++ b/request-for-talk.md
@@ -1,6 +1,12 @@
 # Request a talk!
+[Create an issue here](https://github.com/PDXNode/pdxnode/issues?milestone=1&state=open). Copy the template below and apply the label "request a speaker".  
 
-To request a talk, copy from below the dashed line, and fill in the pertinent bits:
+View currently [submitted](https://github.com/PDXNode/pdxnode/issues?milestone=1&page=1&state=open) talks as well as [talks that have already taken
+place](https://github.com/PDXNode/pdxnode/issues?milestone=1&page=1&state=closed).  
+
+
+To request a talk, copy from below the dashed line, and fill in the
+pertinent bits:
 
 ----------------------
 


### PR DESCRIPTION
Moving forward, method for requesting talks will be via GH issues filed with the label "request a speaker". Added instruction in README.
